### PR TITLE
fix: iOS 오디오 글리치 및 커스터마이징 세션 버그 수정, 모바일 최적화 및 오디오 시스템 재설계

### DIFF
--- a/game/templates/game/presentation.html
+++ b/game/templates/game/presentation.html
@@ -60,7 +60,7 @@
     
     <div class="qr-container">
         <div class="qr-info">
-            <h3><a href="{% url 'game:customize' %}" style="color:inherit; text-decoration:underline;">게임 참여하기</a></h3>
+            <h3><a href="{% url 'game:customize' %}" class="game-link">게임 참여하기</a></h3>
             <p>QR코드를 스캔하여 직접 도전해보세요!</p>
         </div>
         <div class="qr-code">

--- a/static/css/presentation.css
+++ b/static/css/presentation.css
@@ -54,7 +54,7 @@ body {
     grid-area: header;
     background-color: rgba(0, 0, 0, 0.8);
     color: white;
-    padding: 20px 40px;
+    padding: 8px 30px;
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -78,8 +78,8 @@ body {
 }
 
 .game-logo h1 {
-    font-size: 3rem;
-    margin-bottom: 5px;
+    font-size: 2rem;
+    margin-bottom: 0;
     color: var(--primary-color);
     text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
     font-weight: 700;
@@ -87,13 +87,13 @@ body {
 }
 
 .game-logo .tagline {
-    font-size: 1.5rem;
+    font-size: 1rem;
     opacity: 0.9;
     color: var(--accent-color);
 }
 
 .school-logo {
-    height: 100px;
+    height: 50px;
 }
 
 .school-logo img {
@@ -103,20 +103,21 @@ body {
 
 .leaderboard-content {
     grid-area: content;
-    padding: 20px 40px;
+    padding: 15px 40px;
     background-color: rgba(255, 255, 255, 0.9);
     overflow: hidden;
     display: flex;
     flex-direction: column;
+    flex: 1;
 }
 
 .leaderboard-content h2 {
     font-size: 2.5rem;
-    margin-bottom: 20px;
+    margin-bottom: 15px;
     color: var(--dark-color);
     text-align: center;
     border-bottom: 3px solid var(--primary-color);
-    padding-bottom: 10px;
+    padding-bottom: 8px;
     font-weight: 700;
     font-family: 'Spoqa Han Sans Neo', sans-serif;
 }
@@ -141,6 +142,7 @@ body {
     position: relative;
     height: auto;
     min-height: 300px;
+    margin-bottom: 10px;
 }
 
 .player-card:hover {
@@ -274,11 +276,11 @@ body {
     grid-area: qr;
     background-color: rgba(0, 0, 0, 0.8);
     color: white;
-    padding: 15px 40px;
+    padding: 8px 30px;
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     align-items: center;
-    gap: 30px;
+    gap: 20px;
 }
 
 .qr-info {
@@ -286,8 +288,8 @@ body {
 }
 
 .qr-info h3 {
-    font-size: 2.6rem;
-    margin-bottom: 10px;
+    font-size: 1.8rem;
+    margin-bottom: 2px;
     color: var(--primary-color);
     font-weight: 700;
     font-family: 'Spoqa Han Sans Neo', sans-serif;
@@ -295,30 +297,58 @@ body {
 }
 
 .qr-info p {
-    font-size: 1.2rem;
+    font-size: 0.9rem;
     opacity: 0.9;
 }
 
 .qr-code img {
-    width: 150px;
-    height: 150px;
+    width: 80px;
+    height: 80px;
     background-color: white;
-    padding: 10px;
-    border-radius: 10px;
+    padding: 6px;
+    border-radius: 8px;
+}
+
+/* 게임 참여하기 링크 스타일 */
+.game-link {
+    color: inherit;
+    text-decoration: none;
+    position: relative;
+    transition: color 0.3s;
+}
+
+.game-link:hover {
+    color: #0088cc;
+}
+
+.game-link::after {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 1px;
+    bottom: -2px;
+    left: 0;
+    background-color: #0088cc;
+    transform: scaleX(0);
+    transition: transform 0.3s;
+}
+
+.game-link:hover::after {
+    transform: scaleX(1);
 }
 
 /* 와이드스크린 최적화 */
 @media (min-width: 2000px) {
     .game-logo h1 {
-        font-size: 4rem;
+        font-size: 2.5rem;
     }
     
     .game-logo .tagline {
-        font-size: 2rem;
+        font-size: 1.2rem;
     }
     
     .leaderboard-content h2 {
-        font-size: 3rem;
+        font-size: 2.8rem;
     }
     
     .leaderboard-grid {
@@ -330,16 +360,16 @@ body {
     }
     
     .qr-info h3 {
-        font-size: 2.5rem;
+        font-size: 2rem;
     }
     
     .qr-info p {
-        font-size: 1.5rem;
+        font-size: 1.1rem;
     }
     
     .qr-code img {
-        width: 180px;
-        height: 180px;
+        width: 100px;
+        height: 100px;
     }
 }
 
@@ -378,7 +408,7 @@ body {
     }
     
     .presentation-header {
-        padding: 15px;
+        padding: 10px 15px;
     }
     
     .game-logo h1 {
@@ -402,16 +432,23 @@ body {
     
     .qr-info {
         text-align: center;
-        margin-bottom: 20px;
+        margin-bottom: 30px;
     }
     
     .qr-info h3 {
-        font-size: 2rem;
+        font-size: 2.5rem;
+        margin-bottom: 15px;
+    }
+    
+    .qr-info p {
+        font-size: 1.3rem;
     }
     
     .qr-code img {
-        width: 200px;
-        height: 200px;
+        width: 280px;
+        height: 280px;
+        padding: 10px;
+        box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
     }
 }
 
@@ -427,5 +464,10 @@ body {
     
     .school-logo {
         height: 50px;
+    }
+    
+    .qr-code img {
+        width: 240px;
+        height: 240px;
     }
 } 

--- a/static/js/game.js
+++ b/static/js/game.js
@@ -8,21 +8,36 @@ import { Game } from './modules/game-core.js';
 // 모바일 환경 감지
 const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
+// 전역 변수
+window.gameReady = false;
+window.audioActivated = false;
+
 // 오디오 컨텍스트 활성화 준비
 function prepareAudioContext() {
     // iOS/Safari에서 오디오가 재생되도록 준비
     window.AudioContext = window.AudioContext || window.webkitAudioContext;
     
     // 사용자 인터랙션 감지 시 오디오 활성화
-    const activateAudio = () => {
-        // iOS/모바일 브라우저 오디오 활성화
+    const activateAudio = (e) => {
+        // 오디오 활성화 상태 설정
+        window.audioActivated = true;
+        
+        // 더미 오디오 객체 재생으로 오디오 시스템 활성화
         const silentAudio = new Audio();
-        silentAudio.play().catch(() => {});
+        silentAudio.volume = 0.01;
+        silentAudio.play().then(() => {
+            console.log('오디오 활성화 성공 (사용자 인터랙션)');
+        }).catch(() => {
+            console.log('오디오 활성화 실패 (사용자 인터랙션)');
+        });
+        
+        // 저전력 모드 감지를 위한 준비
+        detectLowPowerMode();
         
         // 이벤트 리스너 제거
-        document.removeEventListener('touchstart', activateAudio);
-        document.removeEventListener('click', activateAudio);
-        document.removeEventListener('keydown', activateAudio);
+        document.removeEventListener('touchstart', activateAudio, { once: true });
+        document.removeEventListener('click', activateAudio, { once: true });
+        document.removeEventListener('keydown', activateAudio, { once: true });
     };
     
     // 사용자 인터랙션 감지 (클릭, 터치, 키보드 입력)
@@ -31,20 +46,99 @@ function prepareAudioContext() {
     document.addEventListener('keydown', activateAudio, { once: true });
 }
 
+// 저전력 모드 감지
+function detectLowPowerMode() {
+    // 배터리 API 확인
+    if ('getBattery' in navigator) {
+        navigator.getBattery().then(battery => {
+            const isLowPower = battery.level < 0.3 || battery.charging === false;
+            
+            if (isLowPower && window.gameInstance) {
+                console.log('배터리 저전력 감지됨: 성능 최적화 활성화');
+                window.gameInstance.lowPowerModeDetected = true;
+                
+                if (window.gameInstance.sounds) {
+                    window.gameInstance.sounds._lowPowerMode = true;
+                }
+            }
+        }).catch(e => {
+            console.log('배터리 API 에러:', e);
+        });
+    }
+    
+    // 프레임 레이트 체크 (저전력 모드에서는 프레임 레이트가 낮아짐)
+    let lastTime = 0;
+    let slowFrames = 0;
+    
+    function checkFrameRate(timestamp) {
+        if (lastTime !== 0) {
+            const delta = timestamp - lastTime;
+            
+            // 프레임 간격이 큰 경우 (저전력 모드 가능성)
+            if (delta > 33) { // 30fps 미만
+                slowFrames++;
+                
+                if (slowFrames > 10 && window.gameInstance) {
+                    console.log('저전력 모드 감지됨: 낮은 프레임 레이트');
+                    window.gameInstance.lowPowerModeDetected = true;
+                    
+                    if (window.gameInstance.sounds) {
+                        window.gameInstance.sounds._lowPowerMode = true;
+                    }
+                    
+                    return; // 감지 완료 후 중단
+                }
+            } else {
+                // 정상 프레임 카운터 리셋
+                slowFrames = Math.max(0, slowFrames - 1);
+            }
+        }
+        
+        lastTime = timestamp;
+        requestAnimationFrame(checkFrameRate);
+    }
+    
+    requestAnimationFrame(checkFrameRate);
+}
+
 // DOM이 로드된 후 게임 초기화
 document.addEventListener('DOMContentLoaded', () => {
     // 오디오 컨텍스트 준비
     prepareAudioContext();
     
     // 게임 초기화 - 모바일에서는 약간 지연 (오디오 컨텍스트 초기화용)
+    const initGame = () => {
+        // 이미 초기화되었으면 무시
+        if (window.gameReady) return;
+        
+        window.gameReady = true;
+        window.gameInstance = new Game();
+        
+        // 모바일에서 저전력 모드 감지 시작
+        if (isMobile) {
+            detectLowPowerMode();
+        }
+    };
+    
     if (isMobile) {
-        // 모바일에서는 오디오 초기화를 위해 짧은 지연 후 게임 시작
-        setTimeout(() => {
-            window.gameInstance = new Game();
-        }, 100);
+        // 모바일에서는 사용자 인터랙션 후 게임 초기화
+        const startOnInteraction = (e) => {
+            // 약간의 지연 후 게임 초기화 (오디오 컨텍스트 초기화 대기)
+            setTimeout(initGame, 100);
+            
+            // 이벤트 리스너 제거
+            document.removeEventListener('touchstart', startOnInteraction);
+            document.removeEventListener('click', startOnInteraction);
+        };
+        
+        document.addEventListener('touchstart', startOnInteraction, { once: true });
+        document.addEventListener('click', startOnInteraction, { once: true });
+        
+        // 백업으로 시간 경과 후 초기화
+        setTimeout(initGame, 1000);
     } else {
         // 데스크톱에서는 즉시 시작
-        window.gameInstance = new Game();
+        initGame();
     }
     
     // 게임 이벤트 시스템 초기화 오류 방지를 위한 안전장치

--- a/static/js/modules/game-audio.js
+++ b/static/js/modules/game-audio.js
@@ -136,7 +136,7 @@ export function initAudio() {
                     // iOS에서는 약간 낮은 볼륨으로 설정 (크래킹 방지)
                     audio.volume = Math.min(0.5, AUDIO_CONFIG.mobileVolume);
                 } else {
-                    audio.volume = isMobile ? AUDIO_CONFIG.mobileVolume : AUDIO_CONFIG.defaultVolume;
+                audio.volume = isMobile ? AUDIO_CONFIG.mobileVolume : AUDIO_CONFIG.defaultVolume;
                 }
                 
                 audio.preload = AUDIO_CONFIG.preloadMode;
@@ -196,14 +196,14 @@ export function initAudio() {
             initOnUserInteraction();
             
             // 그래도 초기화 안되면 빈 객체 반환
-            if (!this._initialized) {
-                return { 
-                    play: () => Promise.resolve(),
-                    pause: () => {},
-                    volume: 0,
-                    currentTime: 0,
-                    paused: true
-                };
+        if (!this._initialized) {
+            return { 
+                play: () => Promise.resolve(),
+                pause: () => {},
+                volume: 0,
+                currentTime: 0,
+                paused: true
+            };
             }
         }
         
@@ -339,11 +339,11 @@ export function playSound(sounds, soundName) {
         const playPromise = audio.play();
         if (playPromise !== undefined) {
             playPromise.catch(e => {
-                // 오류 발생 시 조용히 무시 (개발 모드에서만 로그)
-                if (e.name !== 'NotAllowedError') {
-                    console.log(`Sound play error: ${e.message}`);
-                }
-            });
+            // 오류 발생 시 조용히 무시 (개발 모드에서만 로그)
+            if (e.name !== 'NotAllowedError') {
+                console.log(`Sound play error: ${e.message}`);
+            }
+        });
         }
         
         // 마지막 재생 시간 기록

--- a/static/js/modules/game-core.js
+++ b/static/js/modules/game-core.js
@@ -212,7 +212,7 @@ export class Game {
             
             // 날개 편 상태의 의상 이미지 로드
             try {
-                this.images.customization.flyingOutfit.src = `/static/assets/customization/flying/flying_${this.customization.outfit}.png`;
+            this.images.customization.flyingOutfit.src = `/static/assets/customization/flying/flying_${this.customization.outfit}.png`;
                 handleImageError(this.images.customization.flyingOutfit, 'flyingOutfit', this.customization.outfit);
             } catch (e) {
                 console.warn(`날개 편 의상 이미지 로드 실패: ${e.message}`);

--- a/static/js/modules/game-core.js
+++ b/static/js/modules/game-core.js
@@ -379,9 +379,47 @@ export class Game {
     
     // 게임 루프
     gameLoop(timestamp) {
+        // 첫 프레임 처리
         if (this.lastFrameTime === 0) {
             this.lastFrameTime = timestamp;
+            this.fps = 0;
+            this.frameCount = 0;
+            this.frameTime = 0;
+            this.lastFpsUpdate = timestamp;
+            this.lowPowerModeDetected = false;
+            this.targetFrameTime = 1000 / 60; // 60fps를 목표
+            requestAnimationFrame((timestamp) => this.gameLoop(timestamp));
+            return;
         }
+        
+        // 델타 타임 계산 (초 단위)
+        const delta = (timestamp - this.lastFrameTime) / 1000;
+        this.lastFrameTime = timestamp;
+        
+        // FPS 계산 및 저전력 모드 감지
+        this.frameCount++;
+        this.frameTime += delta;
+        
+        if (timestamp - this.lastFpsUpdate >= 1000) {
+            this.fps = this.frameCount;
+            this.frameCount = 0;
+            this.lastFpsUpdate = timestamp;
+            
+            // 저전력 모드 감지
+            if (this.fps < 30 && !this.lowPowerModeDetected) {
+                this.lowPowerModeDetected = true;
+                console.log('저전력 모드 감지: 게임 성능 최적화 적용');
+                
+                // 저전력 모드에서 오디오 최적화
+                if (this.sounds && this.sounds._initialized) {
+                    this.sounds._lowPowerMode = true;
+                }
+            }
+        }
+        
+        // 최대 델타 타임 제한 (너무 긴 프레임 간격으로 인한 "터널링" 방지)
+        const maxDelta = 0.1; // 최대 100ms (10fps)
+        const clampedDelta = Math.min(delta, maxDelta);
         
         if (!this.gameOver) {
             if (this.countdownState.active) {
@@ -430,6 +468,9 @@ export class Game {
                     }
                 }
                 
+                // 절전 모드에서는 처리를 더 단순화
+                const useSimplifiedPhysics = this.lowPowerModeDetected && this.isMobile;
+                
                 // 게임 상태 업데이트
                 const gameState = {
                     canvas: this.canvas,
@@ -441,12 +482,14 @@ export class Game {
                     currentStage: this.currentStage,
                     stageTransitioning: this.stageTransitioning,
                     stageTransitionProgress: this.stageTransitionProgress,
-                    stageTransitionSpeed: this.stageTransitionSpeed,
-                    fSpawnRate: this.fSpawnRate,
-                    aPlusSpawnRate: this.aPlusSpawnRate
+                    stageTransitionSpeed: this.stageTransitionSpeed * (useSimplifiedPhysics ? 1.5 : 1.0), // 절전 모드에서 전환 속도 증가
+                    fSpawnRate: this.fSpawnRate * (useSimplifiedPhysics ? 0.7 : 1.0), // 절전 모드에서 장애물 생성 감소
+                    aPlusSpawnRate: this.aPlusSpawnRate * (useSimplifiedPhysics ? 0.7 : 1.0), // 절전 모드에서 아이템 생성 감소
+                    obstacleSpeedMultiplier: this.obstacleSpeedMultiplier,
+                    deltaTime: clampedDelta // 델타 타임 전달
                 };
                 
-                // 물리 업데이트
+                // 물리 업데이트 - 프레임 속도 독립적
                 const isGameOver = updateGamePhysics(gameState, {
                     onObstacleCollision: () => {
                         this.health--;
@@ -459,10 +502,16 @@ export class Game {
                     onItemCollected: (item) => {
                         if (item.type === 'A+') {
                             this.score += 100;
-                            playSound(this.sounds, 'aplus');
+                            // 절전 모드에서는 사운드 재생을 최소화
+                            if (!useSimplifiedPhysics) {
+                                playSound(this.sounds, 'aplus');
+                            }
                         } else {
                             this.score += 50;
-                            playSound(this.sounds, 'coin');
+                            // 절전 모드에서는 사운드 재생을 최소화
+                            if (!useSimplifiedPhysics) {
+                                playSound(this.sounds, 'coin');
+                            }
                         }
                         this.itemsCollected++;
                         updateScore(this.score);
@@ -487,9 +536,14 @@ export class Game {
                 this.stageTransitionProgress = gameState.stageTransitionProgress;
                 
                 if (!isGameOver) {
-                    // 새 장애물과 아이템 생성
-                    spawnObstacle(this);
-                    spawnItem(this);
+                    // 절전 모드에서는 장애물과 아이템 생성 빈도 줄임
+                    const shouldSpawn = !useSimplifiedPhysics || Math.random() > 0.3;
+                    
+                    if (shouldSpawn) {
+                        // 새 장애물과 아이템 생성
+                        spawnObstacle(this);
+                        spawnItem(this);
+                    }
                     
                     // 게임 렌더링
                     const renderState = {
@@ -503,17 +557,28 @@ export class Game {
                         currentStage: this.currentStage,
                         stageTransitioning: this.stageTransitioning,
                         stageTransitionProgress: this.stageTransitionProgress,
-                        professorData: this.professorData
+                        professorData: this.professorData,
+                        lowPowerMode: this.lowPowerModeDetected
                     };
                     
                     drawGame(this.ctx, renderState, this.images);
                 }
             }
             
-            requestAnimationFrame((timestamp) => this.gameLoop(timestamp));
+            // 저전력 모드에서는 프레임 레이트 제한
+            if (this.lowPowerModeDetected && this.isMobile) {
+                // 30fps로 제한
+                const elapsed = timestamp - this.lastFrameTime;
+                const targetDelay = 1000 / 30; // 30fps
+                const delay = Math.max(0, targetDelay - elapsed);
+                
+                setTimeout(() => {
+                    requestAnimationFrame((timestamp) => this.gameLoop(timestamp));
+                }, delay);
+            } else {
+                requestAnimationFrame((timestamp) => this.gameLoop(timestamp));
+            }
         }
-        
-        this.lastFrameTime = timestamp;
     }
     
     // 게임 타이머 시작
@@ -693,20 +758,77 @@ export class Game {
     // 오디오 컨텍스트 활성화
     activateAudioContext() {
         try {
+            // 이미 활성화 플래그가 설정되어 있으면 건너뜀
+            if (window.audioActivated) {
+                console.log('오디오 컨텍스트가 이미 활성화되어 있습니다.');
+                return;
+            }
+            
+            // 전역 활성화 플래그 설정
+            window.audioActivated = true;
+            
             // 무음 오디오를 재생하여 오디오 컨텍스트 활성화 시도
             const silentAudio = new Audio();
             silentAudio.volume = 0.01;
-            silentAudio.play().catch(() => {
+            
+            // Promise 처리를 통한 오류 관리
+            silentAudio.play().then(() => {
+                console.log('오디오 컨텍스트 활성화 성공');
+                
+                // 게임 오디오 시스템 활성화
+                if (this.sounds && typeof this.sounds.activateAudio === 'function') {
+                    this.sounds.activateAudio();
+                }
+            }).catch(() => {
                 console.log('첫 오디오 재생 시도 실패: 사용자 상호작용 필요');
                 
-                // 사용자가 키보드를 누르면 즉시 오디오 활성화
-                const keyHandler = () => {
-                    const audio = new Audio();
-                    audio.volume = 0.01;
-                    audio.play().catch(() => {});
-                    document.removeEventListener('keydown', keyHandler);
-                };
-                document.addEventListener('keydown', keyHandler, { once: true });
+                // 모바일 환경에서의 특별 처리
+                if (this.isMobile) {
+                    // 터치 이벤트 감지 시 오디오 활성화
+                    const touchHandler = () => {
+                        console.log('터치 이벤트 감지됨: 오디오 컨텍스트 활성화 시도');
+                        
+                        // 오디오 객체 생성 및 재생
+                        const audio = new Audio();
+                        audio.volume = 0.01;
+                        audio.play().then(() => {
+                            console.log('오디오 컨텍스트 활성화 성공 (터치 이벤트 후)');
+                            
+                            // 게임 오디오 시스템 활성화
+                            if (this.sounds && typeof this.sounds.activateAudio === 'function') {
+                                this.sounds.activateAudio();
+                            }
+                        }).catch(() => {});
+                        
+                        // 이벤트 핸들러 제거
+                        document.removeEventListener('touchstart', touchHandler);
+                    };
+                    
+                    // 터치 이벤트 감지
+                    document.addEventListener('touchstart', touchHandler, { once: true, passive: true });
+                } else {
+                    // 사용자가 키보드를 누르면 즉시 오디오 활성화
+                    const keyHandler = () => {
+                        console.log('키보드 이벤트 감지됨: 오디오 컨텍스트 활성화 시도');
+                        
+                        const audio = new Audio();
+                        audio.volume = 0.01;
+                        audio.play().then(() => {
+                            console.log('오디오 컨텍스트 활성화 성공 (키보드 이벤트 후)');
+                            
+                            // 게임 오디오 시스템 활성화
+                            if (this.sounds && typeof this.sounds.activateAudio === 'function') {
+                                this.sounds.activateAudio();
+                            }
+                        }).catch(() => {});
+                        
+                        // 이벤트 핸들러 제거
+                        document.removeEventListener('keydown', keyHandler);
+                    };
+                    
+                    // 키보드 이벤트 감지
+                    document.addEventListener('keydown', keyHandler, { once: true });
+                }
             });
         } catch (e) {
             console.warn('오디오 컨텍스트 활성화 실패:', e);


### PR DESCRIPTION
## 🔘 담당 영역
- [x] 프론트엔드 (Frontend)
- [x] UI/UX
- [x] 기타 (Other): 게임 성능, 오디오 시스템, SEO 개선
- fix: #63 
<br/>

## 🔎 작업 내용
### 🔊 오디오 시스템 재설계 및 최적화
- AudioContext 초기화를 브라우저 autoplay 정책에 맞게 재작성
- 사용자 인터랙션 이후에만 오디오 활성화되도록 처리
- 오디오 초기화 실패 시 예외 처리 및 fallback 로직 구현
- 모바일 장치 성능을 고려한 **비동기 사운드 재생** 및 **오디오 풀 크기 감소**
- 점프 등 반복 효과음에 **오디오 스로틀링** 적용

### 🔋 저전력 모드 대응
- Battery API 및 프레임 분석 기반 **저전력 모드 감지 기능** 추가
- 감지 시 오디오 재생 빈도 줄이고 음원 수 최소화
- FPS 제한을 통해 성능 일관성 확보

### 🖼️ 프레임레이트 독립성 확보
- 델타타임 기반 물리 처리 적용 (프레임 독립적 움직임 구현)
- 저전력 모드에서 FPS 제한으로 게임 안정화

### 🧩 세션 커스터마이징 문제 수정
- `game_view`에서 player_id 없을 경우에도 기존 세션 커스터마이징 값을 유지하도록 변경
- 세션 값이 없을 때만 `'default'` 세팅

### 🧱 JS 방어적 코드 개선
- 커스터마이징 이미지 로딩 로직에 예외 처리 및 fallback 이미지 제공
- API 요청 시 유효성 검사 및 누락 데이터 방지 처리

### 🔗 발표용 링크 및 SEO 구조 강화
- 리더보드의 "게임 참여하기"를 `/game/customize`로 연결
- `color: inherit; text-decoration: underline` 적용

<br/>

## 📝 변경 이유
- iOS Safari 환경에서의 오디오 글리치와 프레임 드랍 개선
- 모바일 저사양 환경에서도 원활한 실행 보장
- 기존 세션 커스터마이징 정보 무시되는 버그 해결
- 구글 SEO에서 사이트 구조를 명확하게 인식하게 하기 위함

<br/>

## 🖼️ 스크린샷
### Before
- iOS에서 연속 점프 시 글리치 발생
- 커스터마이징 세션 값 무시됨
- "게임 참여하기" 링크 없음

### After
- 오디오 재생 안정화 및 프레임 유지
- 세션 기반 커스터마이징 정상 반영
- "게임 참여하기" → `/game/customize` 연결됨

<br/>

## 🧪 테스트 방법
1. iPhone 13 Pro (iOS 16)에서 점프/클릭 반복 → FPS/사운드 확인
2. `/game/play` 접속 전 outfit 세션 값 주입 → 캐릭터 커스터마이징 반영 여부 확인
3. `/game/leaderboard` → "게임 참여하기" → `/game/customize` 이동 확인
4. 모바일 저전력 모드 상태에서 효과음 재생 빈도 확인

<br/>

## 🔄 작업 컨텍스트
